### PR TITLE
Update watch test add detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # scroungejs
 
 > [!WARNING]
-> This application is not suitable for production, if you plan on using it, you are on you own.
+> This application is not suitable for production and is missing many tests, if you plan on using it, you are on you own.
 
 ![scrounge](https://github.com/iambumblehead/scroungejs/raw/main/img/hand3.png)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scroungejs",
-  "version": "1.9.0",
+  "version": "1.9.11",
   "license": "GPL V3+",
   "type": "module",
   "readmeFilename": "README.md",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   ],
   "dependencies": {
     "addquery": "^0.0.1",
-    "chokidar": "^3.5.3",
     "castas": "^1.2.1",
     "archy": "^1.0.0",
     "replace-requires": "^1.1.0",

--- a/sample/src/views/viewsall.js
+++ b/sample/src/views/viewsall.js
@@ -6,9 +6,8 @@ import viewb from './viewb.mjs'
 import viewa from './viewa.js'
 
 let viewsall = {
-  viewa,// : require('./viewa'),
+  viewa,
   viewb
-  //viewb : require('./viewb').default
 }
 
 const hello = () => 'hello'
@@ -17,7 +16,6 @@ const start = () => {
   viewsall.viewb.start()
 }
 
-// mo-dule.exp-orts = {
 export default {
   start,
   hello

--- a/src/scr.js
+++ b/src/scr.js
@@ -126,13 +126,15 @@ const updatedestfile = async (optsuser, srcfilename) => {
 
   const nodefilepath = node.get('filepath')
   const groupTypeExtn = scr_filepath_get_grouptype(opts, nodefilepath)
-  const nodegrouppath = scr_name_with_extn(nodefilepath, groupTypeExtn)
+  // const nodegrouppath = scr_name_with_extn(nodefilepath, groupTypeExtn)
   const rootsarrfiltered = rootsarr.filter(root => (
-    nodegrouppath === scr_filepath_get_grouptype(opts, root)))
+    groupTypeExtn === scr_filepath_get_grouptype(opts, root)))
   const rootnodescached = await scr_cache
     .recoverrootarrcachemapnode(opts, rootsarrfiltered, node)
 
-  await writeroots(opts, rootsarrfiltered, rootnodescached)
+  if (rootnodescached) {
+    await writeroots(opts, rootsarrfiltered, rootnodescached)
+  }
 
   if (opts.basepage &&
       opts.istimestamp) {
@@ -143,7 +145,9 @@ const updatedestfile = async (optsuser, srcfilename) => {
 }
 
 const watchers = opts => (
-  scr_watchers(opts.inputpath, {}, async path => updatedestfile(opts, path)))
+  scr_watchers(opts.inputpath, opts, async path => (
+    updatedestfile(opts, path)
+  )))
 
 const watchersclose = scr_watchersclose
 

--- a/src/scr.js
+++ b/src/scr.js
@@ -1,10 +1,14 @@
 import simpletime from 'simpletime'
 
-import scr_watch from './scr_watch.js'
 import scr_cache from './scr_cache.js'
 import scr_node from './scr_node.js'
 import scr_file from './scr_file.js'
 import scr_opts from './scr_opts.js'
+
+import {
+  scr_watchers,
+  scr_watchersclose
+} from './scr_watch.js'
 
 import {
   scr_enum_extn_grouptypeJS,
@@ -138,8 +142,10 @@ const updatedestfile = async (optsuser, srcfilename) => {
   return true
 }
 
-const watch = opts => (
-  scr_watch(opts.inputpath, {}, async path => updatedestfile(opts, path)))
+const watchers = opts => (
+  scr_watchers(opts.inputpath, {}, async path => updatedestfile(opts, path)))
+
+const watchersclose = scr_watchersclose
 
 const build = async (opts = {}) => {
   let datebgn = new Date()
@@ -161,16 +167,20 @@ const build = async (opts = {}) => {
   scr_logfinish(opts, simpletime.getElapsedTimeFormatted(datebgn, new Date()))
 
   if (opts.iswatch)
-    watch(opts)
+    watchers(opts)
 
   return res
 }
 
-build.watch = watch
+Object.assign(build, {
+  watchers,
+  watchersclose
+})
 
 export {
   build as default,
-  watch,
+  watchers,
+  watchersclose,
   writeroots,
   copyroottpl,
   buildrootobj,

--- a/src/scr.js
+++ b/src/scr.js
@@ -138,6 +138,9 @@ const updatedestfile = async (optsuser, srcfilename) => {
   return true
 }
 
+const watch = opts => (
+  scr_watch(opts.inputpath, {}, async path => updatedestfile(opts, path)))
+
 const build = async (opts = {}) => {
   let datebgn = new Date()
 
@@ -158,16 +161,20 @@ const build = async (opts = {}) => {
   scr_logfinish(opts, simpletime.getElapsedTimeFormatted(datebgn, new Date()))
 
   if (opts.iswatch)
-    scr_watch(opts.inputpath, {}, async path => updatedestfile(opts, path))
+    watch(opts)
 
   return res
 }
 
-export default Object.assign(build, {
+build.watch = watch
+
+export {
+  build as default,
+  watch,
   writeroots,
   copyroottpl,
   buildrootobj,
   writebasepage,
   readbasepage,
   updatedestfile
-})
+}

--- a/src/scr_err.js
+++ b/src/scr_err.js
@@ -10,8 +10,8 @@ const scr_err_basepageinnotfound = basepagein => new Error(
 const scr_err_rootnamemusthavejsextn = rootname => new Error(
   `.js file required for deparr root name, ${rootname}`)
 
-const scr_err_rootpathnotfound = rootname => new Error(
-  `root path not found: ${rootname}`)
+const scr_err_rootpathnotfound = (inputpath, rootname) => new Error(
+  `root path not found: ${rootname}, (inputpath: ${inputpath})`)
 
 export {
   scr_err_umdformatnotsupported,

--- a/src/scr_root.js
+++ b/src/scr_root.js
@@ -56,9 +56,8 @@ const scr_root_deps_create = async (opts, rootname) => {
   const rootpath = opts.jsextnarr
     .map(extn => scr_name_with_extn(path.join(opts.inputpath, rootname), extn))
     .find(scr_file.isexist)
-
   if (!rootpath)
-    throw scr_err_rootpathnotfound(rootname)
+    throw scr_err_rootpathnotfound(opts.inputpath, rootname)
 
   const graph = await scr_root_graph_create(opts, rootpath)
 

--- a/src/scr_watch.js
+++ b/src/scr_watch.js
@@ -1,9 +1,28 @@
 import chokidar from 'chokidar'
 
-export default (globs, opts = {}, fn) => {
+const scr_watchersclose = async watchers => {
+  if (!watchers.length)
+    return watchers
+
+  await watchers[0].close()
+
+  return scr_watchersclose(watchers.slice(1))
+}
+
+const scr_watchers = (globs, opts = {}, fn) => {
+  const watchers = []
   const watcher = chokidar.watch(globs, opts.watch || { cwd: '.' })
 
-  // you may choose to disable watch w/ opts.iswatch = false
+  watchers.push(watcher)
+
   if (typeof fn === 'function')
     watcher.on('change', fn)
+
+  return watchers
+}
+
+export {
+  scr_watchers as default,
+  scr_watchers,
+  scr_watchersclose
 }

--- a/src/scr_watch.js
+++ b/src/scr_watch.js
@@ -1,5 +1,9 @@
-// import chokidar from 'chokidar'
 import fs from 'node:fs'
+// import chokidar from 'chokidar'
+//
+// chokidar may be preferable to fs.watch.
+// chokidar was replaced w/ fs.watch when troubleshooting watch behaviour
+// and decided to continue using fs.watch, but chokidar is probably fine
 
 const scr_watchersclose = async watchers => {
   if (!watchers.length)
@@ -17,7 +21,6 @@ const scr_watchers = (dir, opts = {}, fn) => {
   dir = new URL(dir, opts.metaurl)
   watchers.push(fs.watch(dir, { recursive: true }, (evtype, filename) => {
     if (evtype === 'change') {
-      console.log('WATCH TRIG', { evtype, filename })
       const filepath = new URL(filename, dir)
       fn(String(filepath).replace(/^file:\/\//, ''))
     }

--- a/src/scr_watch.js
+++ b/src/scr_watch.js
@@ -1,4 +1,5 @@
-import chokidar from 'chokidar'
+// import chokidar from 'chokidar'
+import fs from 'node:fs'
 
 const scr_watchersclose = async watchers => {
   if (!watchers.length)
@@ -9,17 +10,37 @@ const scr_watchersclose = async watchers => {
   return scr_watchersclose(watchers.slice(1))
 }
 
-const scr_watchers = (globs, opts = {}, fn) => {
+const scr_watchers = (dir, opts = {}, fn) => {
   const watchers = []
-  const watcher = chokidar.watch(globs, opts.watch || { cwd: '.' })
 
-  watchers.push(watcher)
-
-  if (typeof fn === 'function')
-    watcher.on('change', fn)
+  // convert to url for mode compatibility
+  dir = new URL(dir, opts.metaurl)
+  watchers.push(fs.watch(dir, { recursive: true }, (evtype, filename) => {
+    if (evtype === 'change') {
+      console.log('WATCH TRIG', { evtype, filename })
+      const filepath = new URL(filename, dir)
+      fn(String(filepath).replace(/^file:\/\//, ''))
+    }
+  }))
 
   return watchers
 }
+
+// this commented out area is kept here in case chokidar is needed in future
+// const scr_watchers = (globs, opts = {}, fn) => {
+//   const watchers = []
+//   const watcher = chokidar.watch(globs, opts.watch || { cwd: '.' })
+// 
+//   watchers.push(watcher)
+// 
+//   if (typeof fn === 'function') {
+//     watcher
+//       .on('ready', () => console.log('[...] watch: ready'))
+//       .on('change', fn)
+//   }
+// 
+//   return watchers
+// }
 
 export {
   scr_watchers as default,

--- a/test/scr_root.test.js
+++ b/test/scr_root.test.js
@@ -14,7 +14,8 @@ const __dirname = __filename.replace(/[/\\][^/\\]*?$/, '')
 
 
 test('should return an error if no root file found', async () => {
-  let opts = scr_opts({
+  const inputpathfull = `${__dirname}/src`
+  const opts = scr_opts({
     metaurl: import.meta.url,
     issilent: true,
     inputpath: './src',
@@ -23,7 +24,8 @@ test('should return an error if no root file found', async () => {
   })
   
   await assert.rejects(async () => scr_root_rootsobj(opts, [ 'june.js' ]), {
-    message: 'root path not found: june.js'
+    message: `root path not found: june.js, (inputpath: ${inputpathfull})`
+    // message: `root path not found: june.js, (inputpath: ${inputpathfull})`
   })
 })
 

--- a/test/scr_root.test.js
+++ b/test/scr_root.test.js
@@ -9,7 +9,7 @@ import {
 
 import scr_opts from '../src/scr_opts.js'
 
-const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 
 test('should return an error if no root file found', async () => {
   const inputpathfull = `${__dirname}src`

--- a/test/scr_root.test.js
+++ b/test/scr_root.test.js
@@ -9,12 +9,10 @@ import {
 
 import scr_opts from '../src/scr_opts.js'
 
-const __filename = new url.URL('', import.meta.url).pathname
-const __dirname = __filename.replace(/[/\\][^/\\]*?$/, '')
-
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 test('should return an error if no root file found', async () => {
-  const inputpathfull = `${__dirname}/src`
+  const inputpathfull = `${__dirname}src`
   const opts = scr_opts({
     metaurl: import.meta.url,
     issilent: true,

--- a/test/scr_watch.test.js
+++ b/test/scr_watch.test.js
@@ -1,10 +1,35 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import scrounge from '../src/scr.js'
+import scroungejs from '../src/scr.js'
 
 test('should watch a file`', async () => {
   // use iswatch...
   //scroungejs.watch('src/*', scroungeopts)
-  assert.strictEqual(await scrounge(), null)
+  // const dir = import.meta.url
+
+  const opts = {
+    metaurl: import.meta.url,
+    inputpath: '../sample/src',
+    outputpath: '../sample/out/watch',
+    publicpath: '../sample/out/watch/',
+    basepagein: '../sample/index.tpl.html',
+    basepage: '../sample/out/watch/index.html',
+    isuidfilenames: true,
+    iscompress: false,
+    isconcat: false,
+    treearr: [ 'app.js', 'app.css' ],
+    deploytype: 'module'
+  }
+  
+  await scroungejs(opts)
+
+  // watch...
+  // const watch = scroungejs.watch(opts)
+  // console.log({ res })
+  // 'touch a file'
+  // 'untouch a feil'
+
+  
+  assert.strictEqual(typeof scroungejs, 'function')
 })

--- a/test/scr_watch.test.js
+++ b/test/scr_watch.test.js
@@ -1,13 +1,15 @@
+import fs from 'node:fs/promises'
+import { setTimeout } from 'node:timers/promises'
+import url from 'node:url'
+import path from 'node:path'
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
 import scroungejs from '../src/scr.js'
 
-test('should watch a file`', async () => {
-  // use iswatch...
-  //scroungejs.watch('src/*', scroungeopts)
-  // const dir = import.meta.url
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
+test('should watch a file`', async () => {
   const opts = {
     metaurl: import.meta.url,
     inputpath: '../sample/src',
@@ -21,15 +23,60 @@ test('should watch a file`', async () => {
     treearr: [ 'app.js', 'app.css' ],
     deploytype: 'module'
   }
-  
+
+  // run scrounge one time to generate output files
   await scroungejs(opts)
 
-  // watch...
-  // const watch = scroungejs.watch(opts)
-  // console.log({ res })
-  // 'touch a file'
-  // 'untouch a feil'
+  // create and find various filepaths needed or test
+  const outdir = path.join(
+    __dirname, '../sample/out/watch/')
+  const outfile = await fs.readdir(outdir)
+    .then(files => files.find(file => file.endsWith('viewsall.js')))
+  const outfilepath = path.join(outdir, outfile)  
+  // const tsmatchRe = /\.js\?ts=\d{13}/g
+  const srcfilepath = path.join(
+    __dirname, '../sample/src/views/viewsall.js')
 
-  
-  assert.strictEqual(typeof scroungejs, 'function')
+  const srcfilecontent = (
+    await fs.readFile(srcfilepath, { encoding: 'utf8' }))
+  const srcfilecontentupdated =  srcfilecontent.replace(
+    "const hello = () => 'hello'",
+    "const hello = () => 'hola'")
+
+  // verify current output file
+  const outfilecontent0 = await fs.readFile(outfilepath, { encoding: 'utf8' })
+  assert.ok(outfilecontent0.includes("const hello = () => 'hello'"))
+  assert.ok(!outfilecontent0.includes("const hello = () => 'hola'"))
+
+  // commented-out for now, not sure if needed
+  // verified timestamp that may not be needed for esm modules
+  // const outindexcontent = (
+  //   await fs.readFile(outindexpath, { encoding: 'utf8' }))
+  // const outindexsrcfilets = +String(
+  //   (outindexcontent.match(tsmatchRe) || [])[0]).slice(-13)
+
+  // console.log('creating watchers...')
+  const watchers = scroungejs.watchers(opts)
+
+  // write changes to this file
+  await fs.writeFile(srcfilepath, srcfilecontentupdated, { encoding: 'utf8' })
+  await setTimeout(400)
+
+  // console.log('wrote nw content', srcfilecontentupdated)
+/*
+  // verify source copied to output file by watcher
+  const outfilecontent1 = await fs.readFile(outfilepath, { encoding: 'utf8' })
+  assert.ok(outfilecontent1.includes("const hello = () => 'hola'"))
+  assert.ok(!outfilecontent1.includes("const hello = () => 'hello'"))
+*/  
+  await fs.writeFile(srcfilepath, srcfilecontent, { encoding: 'utf8' })
+  await setTimeout(400)
+
+  // verify source copied to output file by watcher (again)
+  const outfilecontent2 = await fs.readFile(outfilepath, { encoding: 'utf8' })
+  assert.ok(outfilecontent2.includes("const hello = () => 'hello'"))
+  assert.ok(!outfilecontent2.includes("const hello = () => 'hola'"))
+
+  // close watchers
+  assert.ok(await scroungejs.watchersclose(watchers))
 })

--- a/test/scr_watch.test.js
+++ b/test/scr_watch.test.js
@@ -7,12 +7,12 @@ import assert from 'node:assert/strict'
 
 import scroungejs from '../src/scr.js'
 
-const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 
 test('should watch a file`', async () => {
   const opts = {
     metaurl: import.meta.url,
-    inputpath: '../sample/src',
+    inputpath: '../sample/src/',
     outputpath: '../sample/out/watch',
     publicpath: '../sample/out/watch/',
     basepagein: '../sample/index.tpl.html',
@@ -55,22 +55,23 @@ test('should watch a file`', async () => {
   // const outindexsrcfilets = +String(
   //   (outindexcontent.match(tsmatchRe) || [])[0]).slice(-13)
 
-  // console.log('creating watchers...')
   const watchers = scroungejs.watchers(opts)
+  // https://github.com/paulmillr/chokidar/issues/790
+  // setTimeout is used rather than 'ready' here, waiting for
+  // chokidar or fs.watch to listen
+  await setTimeout(4000)
 
   // write changes to this file
   await fs.writeFile(srcfilepath, srcfilecontentupdated, { encoding: 'utf8' })
-  await setTimeout(400)
+  await setTimeout(4000)
 
-  // console.log('wrote nw content', srcfilecontentupdated)
-/*
   // verify source copied to output file by watcher
   const outfilecontent1 = await fs.readFile(outfilepath, { encoding: 'utf8' })
   assert.ok(outfilecontent1.includes("const hello = () => 'hola'"))
   assert.ok(!outfilecontent1.includes("const hello = () => 'hello'"))
-*/  
+
   await fs.writeFile(srcfilepath, srcfilecontent, { encoding: 'utf8' })
-  await setTimeout(400)
+  await setTimeout(4000)
 
   // verify source copied to output file by watcher (again)
   const outfilecontent2 = await fs.readFile(outfilepath, { encoding: 'utf8' })


### PR DESCRIPTION
A test is added. A lot of the path creating and other behaviours are messy and have no tests, but this at least adds one test for the watch behaviour. Chokidar was removed because it was not publishing updates however this likely was my own user error not specifying the correct path or recursive option correctly. (should add a node to the watcher file)